### PR TITLE
Remove G+ link

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,9 +168,6 @@
                 <h2>Contact SZENL</h2>
                 <p>WE ARE HERE, WE ARE WAITING... </p>
                 <ul class="list-inline banner-social-buttons">
-                    <li>
-                        <a href="https://plus.google.com/communities/106617497216462629231" class="btn btn-default btn-lg"><i class="fa fa-google-plus fa-fw"></i> <span class="network-name">Google+</span></a>
-                    </li>
 					<li>
                         <a href="https://telegram.me/szenlguide" class="btn btn-default btn-lg"><i class="fa fa-book fa-fw"></i> <span class="network-name">WIKI</span></a>
                     </li>


### PR DESCRIPTION
Google has removed the g+ link and is no longer available